### PR TITLE
Support destroy for promise subject links

### DIFF
--- a/src/politech_backend/urls.py
+++ b/src/politech_backend/urls.py
@@ -21,38 +21,51 @@ schema_view = get_schema_view(
 urlpatterns = [
     url(r'^$', schema_view, name="docs"),
     url(r'^api/v1/admin/', admin.site.urls),
-    url(r'^api/v1/api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^api/v1/api-auth/',
+        include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api/v1/promises/$', promise_views.PromiseList.as_view()),
-    url(r'^api/v1/promises/(?P<pk>[0-9]+)$', promise_views.PromiseDetails.as_view()),
-    url(r'^api/v1/promises/subjects/$', subject_views.PromiseSubjectList.as_view()),
+    url(r'^api/v1/promises/(?P<pk>[0-9]+)$',
+        promise_views.PromiseDetails.as_view()),
+    url(r'^api/v1/promises/subjects/$',
+        subject_views.PromiseSubjectList.as_view({'get': 'list', 'post': 'create'})),
+    url(r'^api/v1/promises/subjects/(?P<pk>[0-9]+)$',
+        subject_views.PromiseSubjectList.as_view({'get': 'detail', 'delete': 'destroy'})),
     url(r'^api/v1/promiseCases/$', promise_views.PromiseCaseList.as_view()),
-    url(r'^api/v1/promiseCases/(?P<pk>[0-9]+)$', promise_views.PromiseCaseDetails.as_view()),
+    url(r'^api/v1/promiseCases/(?P<pk>[0-9]+)$',
+        promise_views.PromiseCaseDetails.as_view()),
     url(r'^api/v1/cases/$', case_views.CaseList.as_view()),
     url(r'^api/v1/cases/(?P<pk>[0-9]+)$', case_views.CaseDetails.as_view()),
     url(r'^api/v1/parliaments/$', parliament_views.ParliamentList.as_view()),
-    url(r'^api/v1/parliaments/(?P<pk>[0-9]+)$', parliament_views.ParliamentDetails.as_view()),
-    url(r'^api/v1/parliamentSessions/$', parliament_views.ParliamentSessionList.as_view()),
+    url(r'^api/v1/parliaments/(?P<pk>[0-9]+)$',
+        parliament_views.ParliamentDetails.as_view()),
+    url(r'^api/v1/parliamentSessions/$',
+        parliament_views.ParliamentSessionList.as_view()),
     url(
         r'^api/v1/parliamentSessions/(?P<pk>[0-9]+)$',
         parliament_views.ParliamentSessionDetails.as_view()
     ),
     url(r'^api/v1/parties/$', party_views.PartyList.as_view()),
-    url(r'^api/v1/parties/(?P<pk>[0-9]+)$', party_views.PartyDetails.as_view()),
-    url(r'^api/v1/parliamentMembers/$', parliament_views.ParliamentMemberList.as_view()),
+    url(r'^api/v1/parties/(?P<pk>[0-9]+)$',
+        party_views.PartyDetails.as_view()),
+    url(r'^api/v1/parliamentMembers/$',
+        parliament_views.ParliamentMemberList.as_view()),
     url(
         r'^api/v1/parliamentMembers/(?P<pk>[0-9]+)$',
         parliament_views.ParliamentMemberDetails.as_view()
     ),
     url(r'^api/v1/politicians/$', politician_views.PoliticianList.as_view()),
-    url(r'^api/v1/politicians/(?P<pk>[0-9]+)$', politician_views.PoliticianDetails.as_view()),
+    url(r'^api/v1/politicians/(?P<pk>[0-9]+)$',
+        politician_views.PoliticianDetails.as_view()),
     url(r'^api/v1/districts/$', district_views.DistrictList.as_view()),
-    url(r'^api/v1/districts/(?P<pk>[0-9]+)$', district_views.DistrictDetails.as_view()),
+    url(r'^api/v1/districts/(?P<pk>[0-9]+)$',
+        district_views.DistrictDetails.as_view()),
     url(r'^api/v1/subjects/$', subject_views.SubjectList.as_view()),
     url(r'^api/v1/voteRecord/$', vote_views.VoteRecordList.as_view()),
     url(r'^api/v1/vote/$', vote_views.VoteList.as_view()),
 
     url(r'^api/v1/rest-auth/', include('rest_auth.urls')),
-    url(r'^api/v1/rest-auth/registration/', include('rest_auth.registration.urls'))
+    url(r'^api/v1/rest-auth/registration/',
+        include('rest_auth.registration.urls'))
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/src/subjects/views.py
+++ b/src/subjects/views.py
@@ -1,4 +1,4 @@
-from rest_framework import status, generics
+from rest_framework import status, generics, viewsets
 from rest_framework.response import Response
 import django_filters
 
@@ -7,11 +7,13 @@ from .serializers import SubjectSerializer
 from .serializers import PromiseSubjectSerializer
 from .models import PromiseSubject
 
-class PromiseSubjectList(generics.ListCreateAPIView):
+
+class PromiseSubjectList(viewsets.ModelViewSet):
     queryset = PromiseSubject.objects.all()
     serializer_class = PromiseSubjectSerializer
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     filter_fields = ('promise', 'subject')
+
 
 class SubjectFilter(django_filters.rest_framework.FilterSet):
     class Meta:
@@ -21,7 +23,8 @@ class SubjectFilter(django_filters.rest_framework.FilterSet):
             'parent': ['exact'],
             'number': ['exact'],
             'parliament_session': ['exact']
-            }
+        }
+
 
 class SubjectList(generics.ListAPIView):
     '''
@@ -40,10 +43,12 @@ class SubjectList(generics.ListAPIView):
         serializer = SubjectSerializer(data=request.data)
         if serializer.is_valid():
             # We capitalize the subject as we only want to have capitalized subjects
-            serializer.validated_data['name'] = serializer.validated_data['name'].capitalize()
+            serializer.validated_data['name'] = serializer.validated_data['name'].capitalize(
+            )
 
             validated_subject = serializer.validated_data
-            subject_exists = Subject.objects.filter(name=validated_subject['name'])
+            subject_exists = Subject.objects.filter(
+                name=validated_subject['name'])
 
             if subject_exists.exists():
                 # If the subject already exists, we dont want to create a duplicate.


### PR DESCRIPTION
## Status
Ready

## Description
Subjects can be linked to Promises.
Lets also support unlinking

Django Rest supports this with [viewsets](http://www.django-rest-framework.org/api-guide/viewsets/)
## Todos
- [ ] Document
